### PR TITLE
feat(model-routing): thread per-call model through InvokeModelStage

### DIFF
--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -27,9 +27,8 @@ class InvokeModelContext:
     defensive copies — middleware cannot accidentally mutate agent state.
     invocation_state is shared by reference (hooks and tools write to it during streaming).
 
-    ``model`` is the concrete model the terminal will invoke. It defaults to
-    ``agent.model``; middleware (e.g. model routing) may replace it to redirect a single
-    call without mutating shared agent state.
+    ``model`` is the model this call invokes; it starts as ``agent.model`` and middleware
+    may replace it per call.
     """
 
     agent: Agent

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ..agent.agent import Agent
     from ..experimental.bidi import BidiAgent
     from ..interrupt import _InterruptState
+    from ..models.model import Model
     from ..types._events import ModelStopReason, ToolResultEvent, TypedEvent
     from ..types.content import Messages, SystemPrompt
     from ..types.tools import AgentTool, ToolChoice, ToolSpec, ToolUse
@@ -25,6 +26,10 @@ class InvokeModelContext:
     All collection fields (messages, system_prompt, tool_specs, tool_choice) are
     defensive copies — middleware cannot accidentally mutate agent state.
     invocation_state is shared by reference (hooks and tools write to it during streaming).
+
+    ``model`` is the concrete model the terminal will invoke. It defaults to
+    ``agent.model``; middleware (e.g. model routing) may replace it to redirect a single
+    call without mutating shared agent state.
     """
 
     agent: Agent
@@ -33,6 +38,7 @@ class InvokeModelContext:
     tool_specs: list[ToolSpec]
     tool_choice: ToolChoice | None
     invocation_state: dict[str, Any]
+    model: Model
     projected_input_tokens: int | None = None
 
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -537,6 +537,7 @@ async def _handle_model_execution(
                 tool_specs=copy.deepcopy(tool_specs),
                 tool_choice=copy.deepcopy(structured_output_context.tool_choice),
                 invocation_state=invocation_state,
+                model=agent.model,
                 projected_input_tokens=projected_input_tokens,
             )
 
@@ -559,8 +560,7 @@ async def _handle_model_execution(
 
             if last_event is None:
                 raise RuntimeError(
-                    "Middleware chain did not yield a result event. "
-                    "Ensure middleware forwards events from next()."
+                    "Middleware chain did not yield a result event. Ensure middleware forwards events from next()."
                 )
 
             # Write the post-stream model state back to the agent. Skipped on error
@@ -663,7 +663,7 @@ def _make_invoke_model_terminal(
     async def terminal(ctx: InvokeModelContext) -> AsyncGenerator[Any, None]:
         system_prompt_str, system_prompt_content = split_system_prompt(ctx.system_prompt)
 
-        model_id = agent.model.config.get("model_id") if hasattr(agent.model, "config") else None
+        model_id = ctx.model.config.get("model_id") if hasattr(ctx.model, "config") else None
         model_invoke_span = tracer.start_model_invoke_span(
             messages=ctx.messages,
             parent_span=cycle_span,
@@ -675,7 +675,7 @@ def _make_invoke_model_terminal(
         with trace_api.use_span(model_invoke_span, end_on_exit=False):
             try:
                 async for event in stream_messages(
-                    agent.model,
+                    ctx.model,
                     system_prompt_str,
                     ctx.messages,
                     ctx.tool_specs,

--- a/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
+++ b/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
@@ -25,6 +25,7 @@ def make_context(**overrides) -> InvokeModelContext:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=Mock(),
     )
     defaults.update(overrides)
     return InvokeModelContext(**defaults)

--- a/strands-py/tests/strands/injection/test_message_injection.py
+++ b/strands-py/tests/strands/injection/test_message_injection.py
@@ -51,6 +51,7 @@ def invoke_ctx(messages: list[dict], agent: Any = None) -> InvokeModelContext:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=MagicMock(),
     )
 
 

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -1192,6 +1192,7 @@ def _invoke_ctx(messages: list[dict], agent: Any) -> Any:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=getattr(agent, "model", None),
     )
 
 

--- a/strands-py/tests/strands/middleware/test_agent_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_middleware.py
@@ -720,3 +720,38 @@ def test_retry_on_error_use_case():
     result = agent("test")
     assert result.message["content"][0]["text"] == "Success!"
     assert call_count == 3
+
+
+# --- per-call model on context (routing plumbing) ---
+
+
+def test_invoke_model_context_exposes_agent_model(agent):
+    """InvokeModelContext.model defaults to agent.model."""
+    captured: list = []
+
+    async def capture(context, next_fn):
+        captured.append(context.model)
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture)
+    agent("test")
+
+    assert captured == [agent.model]
+
+
+def test_terminal_streams_context_model_override():
+    """The terminal streams the model set on the context, not agent.model."""
+    model_a = MockedModelProvider([{"role": "assistant", "content": [{"text": "A"}]}])
+    model_b = MockedModelProvider([{"role": "assistant", "content": [{"text": "B"}]}])
+    agent = Agent(model=model_a, callback_handler=None)
+    model_a.stream = AsyncMock(wraps=model_a.stream)
+
+    def route_to_b(context):
+        return replace(context, model=model_b)
+
+    agent._middleware_registry.add_middleware(InvokeModelStage.Input, route_to_b)
+    result = agent("test")
+
+    assert result.message["content"][0]["text"] == "B"
+    model_a.stream.assert_not_called()

--- a/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
@@ -40,6 +40,7 @@ def invoke_ctx(messages: list[dict], agent: Any) -> InvokeModelContext:
         tool_specs=[],
         tool_choice=None,
         invocation_state={},
+        model=MagicMock(),
     )
 
 


### PR DESCRIPTION
## Description

First slice of model routing (design `team/designs/0015-model-routing.md`): the per-call model plumbing that later routing middleware builds on.

`InvokeModelStage`'s terminal previously read `agent.model` directly, so nothing could redirect an individual model call without mutating shared agent state (which is unsafe under concurrent invocations). This PR threads the model to invoke through the middleware context instead:

- `InvokeModelContext` gains a required `model: Model`, initialized from `agent.model`.
- The invoke-model terminal streams `ctx.model` (and reads its `model_id` for the span) rather than `agent.model`.

No behavior change for existing single-model agents. This is intentionally a standalone, inert seam; the `ModelRouter` type and strategies land in follow-up PRs.

## Public API Changes

`InvokeModelContext` (consumed by invoke-stage middleware authors) now carries the concrete model for the call, which middleware may replace to redirect a single invocation:

```python
async def route(context, next_fn):
    context = replace(context, model=my_other_model)  # this call streams my_other_model
    async for event in next_fn(context):
        yield event
```

## Related Issues

Refs #364

## Type of Change

New feature

## Testing

- Added tests: context exposes `agent.model` by default; a middleware overriding `ctx.model` redirects the streamed model.
- Full Python unit suite passes locally (`hatch test`); format and lint clean.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my feature works
- [x] My changes generate no new warnings

> Draft: opening early for review of the routing seam before `ModelRouter` lands.
